### PR TITLE
feat(a2a): add simple HMAC-based auth and role checks

### DIFF
--- a/src/a2a/cli.py
+++ b/src/a2a/cli.py
@@ -11,6 +11,7 @@ from ..llm_providers.registry import list_providers
 from ..shared.base_functions import async_to_sync, function_registry
 from ..shared.functions import initialize_functions
 from .agent import AgentChat
+from .security import AuthManager
 
 
 @click.group()
@@ -173,6 +174,49 @@ def set_default_provider(provider: str):
 
     config_manager = get_config_manager()
     config_manager.set_default_provider(provider)
+
+
+@config.group("a2a")
+def config_a2a():
+    """Manage A2A authentication and roles."""
+    pass
+
+
+@config_a2a.command("set-secret")
+@click.argument("secret")
+def a2a_set_secret(secret: str):
+    """Set the A2A HMAC secret (persisted securely)."""
+    config_manager = get_config_manager()
+    config_manager.set_a2a_secret(secret)
+
+
+@config_a2a.command("roles")
+def a2a_list_roles():
+    """List persisted agent roles."""
+    config_manager = get_config_manager()
+    roles = config_manager.list_agent_roles()
+    if not roles:
+        click.echo("No roles configured.")
+        return
+    for agent_id, role in roles.items():
+        click.echo(f"{agent_id}: {role}")
+
+
+@config_a2a.command("set-role")
+@click.argument("agent_id")
+@click.argument("role")
+def a2a_set_role(agent_id: str, role: str):
+    """Assign a role to an agent id."""
+    config_manager = get_config_manager()
+    config_manager.set_agent_role(agent_id, role)
+
+
+@config_a2a.command("remove-role")
+@click.argument("agent_id")
+def a2a_remove_role(agent_id: str):
+    """Remove a role assignment for an agent id."""
+    config_manager = get_config_manager()
+    config_manager.remove_agent_role(agent_id)
 
 
 @config.command("show")

--- a/src/a2a/security.py
+++ b/src/a2a/security.py
@@ -9,15 +9,21 @@ from __future__ import annotations
 import hmac
 import os
 from hashlib import sha256
-from typing import Dict, Optional
+from typing import Optional
+
+from ..llm_providers.config import get_config_manager
 
 
 class AuthManager:
     def __init__(self, secret: Optional[str] = None) -> None:
-        self._secret = (secret or os.environ.get("A2A_SECRET") or "dev-secret").encode(
-            "utf-8"
-        )
-        self._roles: Dict[str, str] = {}  # agent_id -> role
+        config = get_config_manager()
+        resolved_secret = secret or config.get_a2a_secret()
+        if not resolved_secret:
+            raise ValueError(
+                "A2A secret is not configured. Use 'kubestellar config a2a set-secret <VALUE>' or set A2A_SECRET."
+            )
+        self._secret = resolved_secret.encode("utf-8")
+        self._config = config
 
     def issue_token(self, agent_id: str) -> str:
         digest = hmac.new(self._secret, agent_id.encode("utf-8"), sha256).hexdigest()
@@ -28,9 +34,9 @@ class AuthManager:
         return hmac.compare_digest(expected, token)
 
     def set_role(self, agent_id: str, role: str) -> None:
-        self._roles[agent_id] = role
+        self._config.set_agent_role(agent_id, role)
 
     def has_role(self, agent_id: str, required_role: str) -> bool:
-        return self._roles.get(agent_id) == required_role
+        return self._config.get_agent_role(agent_id) == required_role
 
 

--- a/src/a2a/security.py
+++ b/src/a2a/security.py
@@ -1,0 +1,36 @@
+"""Simple authentication and authorization helpers for A2A.
+
+This module provides HMAC-based token validation and role-based checks. It is
+kept minimal for local development and can be replaced by a more robust layer.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+from hashlib import sha256
+from typing import Dict, Optional
+
+
+class AuthManager:
+    def __init__(self, secret: Optional[str] = None) -> None:
+        self._secret = (secret or os.environ.get("A2A_SECRET") or "dev-secret").encode(
+            "utf-8"
+        )
+        self._roles: Dict[str, str] = {}  # agent_id -> role
+
+    def issue_token(self, agent_id: str) -> str:
+        digest = hmac.new(self._secret, agent_id.encode("utf-8"), sha256).hexdigest()
+        return digest
+
+    def verify(self, agent_id: str, token: str) -> bool:
+        expected = self.issue_token(agent_id)
+        return hmac.compare_digest(expected, token)
+
+    def set_role(self, agent_id: str, role: str) -> None:
+        self._roles[agent_id] = role
+
+    def has_role(self, agent_id: str, required_role: str) -> bool:
+        return self._roles.get(agent_id) == required_role
+
+

--- a/tests/test_auth_manager.py
+++ b/tests/test_auth_manager.py
@@ -1,0 +1,25 @@
+from src.a2a.security import AuthManager
+from src.llm_providers.config import get_config_manager
+
+
+def test_auth_manager_uses_config_secret(tmp_path, monkeypatch):
+    # Point config to a temp dir
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    cm = get_config_manager()
+    cm.set_a2a_secret("super-secret")
+
+    auth = AuthManager()
+    token = auth.issue_token("agent-x")
+    assert auth.verify("agent-x", token)
+
+
+def test_roles_are_persistent(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    cm = get_config_manager()
+    cm.set_a2a_secret("super-secret")
+    cm.set_agent_role("agent-y", "coordinator")
+
+    auth = AuthManager()
+    assert auth.has_role("agent-y", "coordinator")
+
+


### PR DESCRIPTION
### Summary
Introduce minimal authentication/authorization primitives for A2A components to gate sensitive operations and prepare for future RBAC integration.

Fixes: #33 

### What’s included
- New `src/a2a/security.py`:
  - `AuthManager` with:
    - `issue_token(agent_id: str) -> str` (HMAC-SHA256)
    - `verify(agent_id: str, token: str) -> bool` (constant-time compare)
    - `set_role(agent_id: str, role: str) -> None`
    - `has_role(agent_id: str, required_role: str) -> bool`
  - Config via `A2A_SECRET` env var; falls back to a development default.

### Why
- Lightweight, dependency-free auth layer to secure A2A message handling.
- Establishes a simple role check future wiring (broker/MCP handlers) can enforce.

### Usage
Set a strong shared secret:
```bash
export A2A_SECRET='replace-with-strong-secret'
```

Example:
```python
from src.a2a.security import AuthManager

auth = AuthManager()  # reads A2A_SECRET
token = auth.issue_token("agent-alpha")

assert auth.verify("agent-alpha", token)

auth.set_role("agent-alpha", "coordinator")
assert auth.has_role("agent-alpha", "coordinator")
```

### Scope and impact
- Not yet wired into broker/MCP handlers; no behavior changes to existing flows.
- No migrations; safe to merge and integrate incrementally.

### Security notes
- Uses HMAC-SHA256 with constant-time comparison.
- Default secret is for development only; production MUST set `A2A_SECRET`.
- Future: token rotation, per-agent secrets, mTLS/OIDC integration.
