### PR TITLE
feat(a2a): add consensus (majority vote), routing helpers, and task distribution

### DIFF
--- a/src/a2a/consensus.py
+++ b/src/a2a/consensus.py
@@ -1,0 +1,72 @@
+"""Lightweight consensus primitives for distributed agent decisions.
+
+Implements a simple majority-vote proposal mechanism suitable for small
+clusters of cooperating agents. Not a replacement for Raft/Paxos.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .broker import A2ABroker
+from .protocol import Message, MessageType
+
+
+@dataclass
+class ProposalResult:
+    proposal_id: str
+    accepted: bool
+    votes_for: int
+    votes_against: int
+    total: int
+    decided_ms: int
+
+
+class MajorityConsensus:
+    """Propose/collect votes with timeouts over the broker."""
+
+    def __init__(self, broker: A2ABroker, agent_id: str) -> None:
+        self.broker = broker
+        self.agent_id = agent_id
+
+    async def propose(self, topic: str, proposal: Dict, voters: int, timeout_ms: int = 1000) -> ProposalResult:
+        proposal_id = proposal.get("id") or str(int(time.time() * 1000))
+        msg = Message(
+            type=MessageType.PROPOSAL,
+            sender_id=self.agent_id,
+            topic=topic,
+            payload={"id": proposal_id, "proposal": proposal},
+        )
+        await self.broker.publish(msg)
+
+        votes_for = 1  # self vote
+        votes_against = 0
+        deadline = time.time() + timeout_ms / 1000.0
+
+        inbox = await self.broker.register_direct_inbox(self.agent_id)
+        while time.time() < deadline and votes_for + votes_against < voters:
+            try:
+                remaining = max(0, deadline - time.time())
+                resp: Message = await asyncio.wait_for(inbox.get(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+            if resp.type == MessageType.VOTE and resp.payload.get("proposal_id") == proposal_id:
+                if resp.payload.get("accept", False):
+                    votes_for += 1
+                else:
+                    votes_against += 1
+
+        accepted = votes_for > votes_against
+        return ProposalResult(
+            proposal_id=proposal_id,
+            accepted=accepted,
+            votes_for=votes_for,
+            votes_against=votes_against,
+            total=voters,
+            decided_ms=int(time.time() * 1000),
+        )
+
+

--- a/src/a2a/router.py
+++ b/src/a2a/router.py
@@ -1,0 +1,31 @@
+"""Inter-AI message routing utilities.
+
+Provides helpers to route messages to topics based on KubeStellar context
+properties and to address agents by capability.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def topic_for_cluster(cluster_name: str) -> str:
+    return f"cluster.{cluster_name}"
+
+
+def topic_for_resource(kind: str) -> str:
+    return f"resource.{kind.lower()}"
+
+
+def topic_for_role(role: str) -> str:
+    return f"role.{role.lower()}"
+
+
+def route_for_task(task: Dict[str, Any]) -> str:
+    if "cluster" in task:
+        return topic_for_cluster(task["cluster"])
+    if "resource_kind" in task:
+        return topic_for_resource(task["resource_kind"])
+    return topic_for_role(task.get("role", "general"))
+
+

--- a/src/a2a/task_distribution.py
+++ b/src/a2a/task_distribution.py
@@ -1,0 +1,30 @@
+"""Task distribution algorithms for A2A coordination."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def round_robin(agents: List[str], tasks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not agents:
+        return []
+    assigned: List[Dict[str, Any]] = []
+    for i, task in enumerate(tasks):
+        agent = agents[i % len(agents)]
+        assigned.append({**task, "assignee": agent})
+    return assigned
+
+
+def by_capacity(agents: List[Dict[str, Any]], tasks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    # agents: [{id: str, capacity: int, load: int}]
+    sorted_agents = sorted(agents, key=lambda a: (a.get("load", 0) / max(a.get("capacity", 1), 1)))
+    assigned: List[Dict[str, Any]] = []
+    idx = 0
+    for task in tasks:
+        agent = sorted_agents[idx % len(sorted_agents)]
+        assigned.append({**task, "assignee": agent["id"]})
+        agent["load"] = agent.get("load", 0) + 1
+        sorted_agents = sorted(sorted_agents, key=lambda a: (a.get("load", 0) / max(a.get("capacity", 1), 1)))
+    return assigned
+
+


### PR DESCRIPTION
### Summary
Introduce lightweight coordination utilities for A2A agents:
- Majority-vote consensus for small groups
- Topic routing helpers
- Simple task distribution strategies

Fixes: #32 

### What’s included
- `src/a2a/consensus.py`
  - `MajorityConsensus` (async): `propose(topic, proposal, voters, timeout_ms)` → `ProposalResult`
  - `ProposalResult`: `{proposal_id, accepted, votes_for, votes_against, total, decided_ms}`
- `src/a2a/router.py`
  - `topic_for_cluster(name)`, `topic_for_resource(kind)`, `topic_for_role(role)`
  - `route_for_task(task)` → topic based on `cluster`/`resource_kind`/`role`
- `src/a2a/task_distribution.py`
  - `round_robin(agents, tasks)` → evenly assigns
  - `by_capacity(agents_with_capacity, tasks)` → load-aware assignment

### Why
- Provide minimal, dependency-free building blocks for distributed decisions and work routing.
- Keep interfaces small and composable, so they can be wired into the broker/MCP in follow-up PRs.

### Usage examples
Consensus:
```python
import asyncio
from src.a2a.consensus import MajorityConsensus
from src.a2a.broker import A2ABroker  # provided by protocol/broker PR

async def main():
  broker = A2ABroker()
  consensus = MajorityConsensus(broker, agent_id="agent-a")
  result = await consensus.propose(
    topic="role.coordinator",
    proposal={"action": "scale", "replicas": 3},
    voters=3,
    timeout_ms=1000,
  )
  print(result.accepted, result.votes_for, result.votes_against)

asyncio.run(main())
```

Routing:
```python
from src.a2a.router import topic_for_cluster, route_for_task

topic = topic_for_cluster("wec-east1")          # "cluster.wec-east1"
topic2 = route_for_task({"resource_kind": "Pod"})# "resource.pod"
```

Task distribution:
```python
from src.a2a.task_distribution import round_robin, by_capacity

agents = ["a1","a2","a3"]
tasks = [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
assigned = round_robin(agents, tasks)

agents_caps = [{"id":"a1","capacity":4,"load":1},
               {"id":"a2","capacity":2,"load":0}]
assigned2 = by_capacity(agents_caps, tasks)
```

### Scope and impact
- Adds coordination helpers only; no changes to runtime behavior yet.
- Zero external dependencies. Safe to merge in isolation.
