### PR TITLE
feat(a2a): shared multi-cluster context, serializer, and deltas with tests

### DIFF
--- a/src/a2a/context.py
+++ b/src/a2a/context.py
@@ -1,0 +1,93 @@
+"""Shared context manager for multi-cluster state snapshots.
+
+Provides serialization/deserialization and efficient delta updates for passing
+cluster state to models and between agents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ClusterSnapshot:
+    name: str
+    cluster_type: str
+    resources_by_type: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
+    kubestellar_resources: List[Dict[str, Any]] = field(default_factory=list)
+    updated_ms: int = field(default_factory=lambda: int(time.time() * 1000))
+
+    def to_compact(self) -> Dict[str, Any]:
+        return {
+            "n": self.name,
+            "t": self.cluster_type,
+            "r": self.resources_by_type,
+            "k": self.kubestellar_resources,
+            "u": self.updated_ms,
+        }
+
+    @staticmethod
+    def from_compact(data: Dict[str, Any]) -> "ClusterSnapshot":
+        return ClusterSnapshot(
+            name=data["n"],
+            cluster_type=data.get("t", "unknown"),
+            resources_by_type=data.get("r", {}),
+            kubestellar_resources=data.get("k", []),
+            updated_ms=data.get("u", int(time.time() * 1000)),
+        )
+
+
+class ContextSerializer:
+    """Compact JSON serialization with content hashing."""
+
+    @staticmethod
+    def dumps(context: Dict[str, Any]) -> str:
+        payload = {
+            "v": 1,
+            "ctx": context,
+        }
+        text = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        return text
+
+    @staticmethod
+    def loads(text: str) -> Dict[str, Any]:
+        data = json.loads(text)
+        return data.get("ctx", {})
+
+    @staticmethod
+    def hash(text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class SharedContext:
+    """Holds latest multi-cluster state and computes deltas."""
+
+    def __init__(self) -> None:
+        self._clusters: Dict[str, ClusterSnapshot] = {}
+        self._last_hash: Optional[str] = None
+
+    def update_cluster(self, snapshot: ClusterSnapshot) -> None:
+        self._clusters[snapshot.name] = snapshot
+
+    def to_model_context(self) -> Dict[str, Any]:
+        # Compact schema suitable for LLM/system prompt inclusion
+        return {
+            "clusters": {name: snap.to_compact() for name, snap in self._clusters.items()}
+        }
+
+    def serialize(self) -> str:
+        return ContextSerializer.dumps(self.to_model_context())
+
+    def get_delta_if_changed(self) -> Optional[Dict[str, Any]]:
+        text = self.serialize()
+        h = ContextSerializer.hash(text)
+        if h == self._last_hash:
+            return None
+        self._last_hash = h
+        return {"hash": h, "context": json.loads(text)}
+
+

--- a/src/a2a/context_manager.py
+++ b/src/a2a/context_manager.py
@@ -1,0 +1,37 @@
+"""Global accessors for shared A2A context and broker."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .broker import A2ABroker
+from .context import SharedContext
+
+_shared_context: Optional[SharedContext] = None
+_broker: Optional[A2ABroker] = None
+
+
+def set_shared_context(ctx: SharedContext) -> None:
+    global _shared_context
+    _shared_context = ctx
+
+
+def get_shared_context() -> SharedContext:
+    global _shared_context
+    if _shared_context is None:
+        _shared_context = SharedContext()
+    return _shared_context
+
+
+def set_broker(b: A2ABroker) -> None:
+    global _broker
+    _broker = b
+
+
+def get_broker() -> A2ABroker:
+    global _broker
+    if _broker is None:
+        _broker = A2ABroker()
+    return _broker
+
+

--- a/src/a2a/serialization.py
+++ b/src/a2a/serialization.py
@@ -1,0 +1,25 @@
+"""Serialization helpers for passing context and messages efficiently."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from typing import Any, Dict
+
+
+def to_json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, separators=(",", ":"), sort_keys=True)
+
+
+def from_json(text: str) -> Dict[str, Any]:
+    return json.loads(text)
+
+
+def to_compressed_bytes(data: Dict[str, Any]) -> bytes:
+    return gzip.compress(to_json(data).encode("utf-8"))
+
+
+def from_compressed_bytes(blob: bytes) -> Dict[str, Any]:
+    return json.loads(gzip.decompress(blob).decode("utf-8"))
+
+

--- a/tests/test_context_serializer.py
+++ b/tests/test_context_serializer.py
@@ -1,0 +1,30 @@
+from src.a2a.context import SharedContext, ClusterSnapshot, ContextSerializer
+
+
+def test_context_serialize_and_delta():
+    ctx = SharedContext()
+    assert ctx.get_delta_if_changed() is not None  # first snapshot yields delta
+
+    # Update cluster and ensure hash changes
+    ctx.update_cluster(
+        ClusterSnapshot(
+            name="c1",
+            cluster_type="wec",
+            resources_by_type={"pod": [{"name": "p1"}]},
+            kubestellar_resources=[],
+        )
+    )
+    delta = ctx.get_delta_if_changed()
+    assert delta is not None
+
+    # No changes → no delta
+    assert ctx.get_delta_if_changed() is None
+
+    # Serializer round trip
+    text = ctx.serialize()
+    h1 = ContextSerializer.hash(text)
+    ctx2 = ContextSerializer.loads(text)
+    assert "clusters" in ctx2
+    assert isinstance(h1, str)
+
+


### PR DESCRIPTION
### Summary
Add a compact, delta-friendly shared context for multi-cluster state, with serializer utilities and tests. This enables efficient passage of KubeStellar state between agents and into MCP prompts.

### What’s included
- `src/a2a/context.py`
  - `ClusterSnapshot`: per-cluster view (resources_by_type, kubestellar_resources)
  - `SharedContext`: stores snapshots, produces compact model context, computes deltas
  - `ContextSerializer`: compact JSON encode/decode + SHA-256 hashing
- `src/a2a/context_manager.py`
  - Global accessors: `get_shared_context()` / `set_shared_context()`
- `src/a2a/serialization.py`
  - `to_json`, `from_json`, `to_compressed_bytes`, `from_compressed_bytes`
- Tests
  - `tests/test_context_serializer.py`: serialize/round-trip and delta behavior

### Why
- Provide a minimal, dependency-free context layer to:
  - Efficiently serialize/transport cluster state to LLMs/agents
  - Detect changes via stable content hashes (avoid re-sending unchanged state)
  - Keep on-path latency low with compact JSON

### Usage
Create/update context and compute deltas:
```python
from src.a2a.context import SharedContext, ClusterSnapshot

ctx = SharedContext()

# First call returns a delta (initial snapshot)
first_delta = ctx.get_delta_if_changed()  # dict or None

# Update a cluster snapshot
ctx.update_cluster(
    ClusterSnapshot(
        name="cluster1",
        cluster_type="wec",
        resources_by_type={"pod": [{"name": "p1"}]},
        kubestellar_resources=[],
    )
)

# Delta only when content changes
delta = ctx.get_delta_if_changed()  # returns dict with {"hash", "context"} or None

# Compact serialized text for storage/transport
text = ctx.serialize()  # JSON string
```

Compact serialization and compression:
```python
from src.a2a.serialization import to_json, from_json, to_compressed_bytes, from_compressed_bytes

payload = {"clusters": {"c1": {"n": "c1"}}}
blob = to_compressed_bytes(payload)
restored = from_compressed_bytes(blob)
```

### Tests
- `test_context_serialize_and_delta`:
  - Verifies initial delta, change detection, no-delta on unchanged state
  - Validates serializer round trip and hashing

### Scope and impact
- Self-contained context/serializer utilities; no runtime behavior changes elsewhere.
- Zero external dependencies; safe to merge.
