### PR TITLE
feat(a2a): introduce protocol envelope and in-process broker with tests

### DIFF
--- a/src/a2a/broker.py
+++ b/src/a2a/broker.py
@@ -1,0 +1,65 @@
+"""In-process A2A message broker with topics and direct delivery.
+
+This is a minimal async broker abstraction to enable testing and local
+coordination. It can be replaced by a distributed backend later (NATS, Redis,
+Kafka). The interface is intentionally small for portability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import AsyncIterator, Dict, Optional, Set
+
+from .protocol import Message
+
+
+class A2ABroker:
+    """Simple async broker supporting pub/sub and direct send."""
+
+    def __init__(self) -> None:
+        self._topic_queues: Dict[str, Set[asyncio.Queue[Message]]] = defaultdict(set)
+        self._direct_queues: Dict[str, asyncio.Queue[Message]] = {}
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, topic: str) -> AsyncIterator[Message]:
+        queue: asyncio.Queue[Message] = asyncio.Queue(maxsize=1024)
+        async with self._lock:
+            self._topic_queues[topic].add(queue)
+
+        try:
+            while True:
+                msg = await queue.get()
+                yield msg
+        finally:
+            async with self._lock:
+                self._topic_queues[topic].discard(queue)
+
+    async def register_direct_inbox(self, agent_id: str) -> asyncio.Queue[Message]:
+        async with self._lock:
+            if agent_id not in self._direct_queues:
+                self._direct_queues[agent_id] = asyncio.Queue(maxsize=1024)
+            return self._direct_queues[agent_id]
+
+    async def publish(self, message: Message) -> None:
+        if message.topic is None:
+            return
+        async with self._lock:
+            for queue in list(self._topic_queues.get(message.topic, [])):
+                # best effort, drop on full to keep latency low
+                if not queue.full():
+                    queue.put_nowait(message)
+
+    async def send(self, message: Message) -> bool:
+        if message.target_id is None:
+            return False
+        async with self._lock:
+            inbox = self._direct_queues.get(message.target_id)
+            if inbox is None:
+                return False
+            if inbox.full():
+                return False
+            inbox.put_nowait(message)
+            return True
+
+

--- a/src/a2a/protocol.py
+++ b/src/a2a/protocol.py
@@ -1,0 +1,80 @@
+"""A2A protocol primitives for agent-to-agent messaging.
+
+Defines message types, envelopes, and helpers for serialization.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class MessageType(str, Enum):
+    REQUEST = "request"
+    RESPONSE = "response"
+    EVENT = "event"
+    HEARTBEAT = "heartbeat"
+    REGISTER = "register"
+    PROPOSAL = "proposal"
+    VOTE = "vote"
+    TASK = "task"
+
+
+@dataclass
+class Message:
+    """Protocol message envelope.
+
+    All messages are routed through a broker by topic or direct target.
+    """
+
+    type: MessageType
+    sender_id: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    topic: Optional[str] = None
+    target_id: Optional[str] = None
+    timestamp_ms: int = field(default_factory=lambda: int(time.time() * 1000))
+    trace_id: Optional[str] = None
+    auth_token: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type.value,
+            "sender_id": self.sender_id,
+            "payload": self.payload,
+            "topic": self.topic,
+            "target_id": self.target_id,
+            "timestamp_ms": self.timestamp_ms,
+            "trace_id": self.trace_id,
+            "auth_token": self.auth_token,
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "Message":
+        return Message(
+            id=data.get("id") or str(uuid.uuid4()),
+            type=MessageType(data["type"]),
+            sender_id=data["sender_id"],
+            payload=data.get("payload", {}),
+            topic=data.get("topic"),
+            target_id=data.get("target_id"),
+            timestamp_ms=data.get("timestamp_ms", int(time.time() * 1000)),
+            trace_id=data.get("trace_id"),
+            auth_token=data.get("auth_token"),
+        )
+
+
+@dataclass
+class AgentInfo:
+    """Registered agent metadata."""
+
+    agent_id: str
+    capabilities: Dict[str, Any] = field(default_factory=dict)
+    last_heartbeat_ms: int = field(default_factory=lambda: int(time.time() * 1000))
+    auth_token_hash: Optional[str] = None
+
+

--- a/tests/test_a2a_protocol_and_broker.py
+++ b/tests/test_a2a_protocol_and_broker.py
@@ -1,0 +1,41 @@
+import asyncio
+
+import pytest
+
+from src.a2a.protocol import Message, MessageType
+from src.a2a.broker import A2ABroker
+
+
+@pytest.mark.asyncio
+async def test_publish_subscribe():
+    broker = A2ABroker()
+    received = []
+
+    async def subscriber():
+        async for msg in broker.subscribe("test.topic"):
+            received.append(msg)
+            break
+
+    task = asyncio.create_task(subscriber())
+    await asyncio.sleep(0)
+    await broker.publish(
+        Message(type=MessageType.EVENT, sender_id="a", topic="test.topic", payload={"x": 1})
+    )
+    await asyncio.wait_for(task, timeout=1)
+    assert len(received) == 1
+    assert received[0].payload["x"] == 1
+
+
+@pytest.mark.asyncio
+async def test_direct_send():
+    broker = A2ABroker()
+    inbox = await broker.register_direct_inbox("agent-b")
+
+    sent = await broker.send(
+        Message(type=MessageType.REQUEST, sender_id="agent-a", target_id="agent-b", payload={"op": "ping"})
+    )
+    assert sent is True
+    msg = await asyncio.wait_for(inbox.get(), timeout=1)
+    assert msg.payload["op"] == "ping"
+
+


### PR DESCRIPTION
### Summary
Introduce foundational A2A messaging primitives:
- A compact protocol envelope (`Message`, `MessageType`)
- An async, in-process broker supporting pub/sub topics and direct messaging
- Unit tests covering publish/subscribe and direct send

Fixes: #30 

### What’s included
- `src/a2a/protocol.py`
  - `MessageType`: `request`, `response`, `event`, `heartbeat`, `register`, `proposal`, `vote`, `task`
  - `Message`: envelope with `id`, `sender_id`, `payload`, `topic` or `target_id`, `timestamp_ms`, optional `trace_id`/`auth_token`, plus `to_dict`/`from_dict`
- `src/a2a/broker.py`
  - `A2ABroker`: async pub/sub (`subscribe`/`publish`) and direct messaging (`register_direct_inbox`/`send`)
  - Drop-on-full queues to keep latency low (loss-tolerant events)
- Tests
  - `tests/test_a2a_protocol_and_broker.py`: verifies topic subscription delivery and direct send to agent inbox

### Why
- Establish a minimal, dependency-free messaging layer for agent coordination and future MCP integration.
- Keep interfaces small, testable, and fast for <100ms command paths.

### Usage
Publish/subscribe on a topic:
```python
import asyncio
from src.a2a.protocol import Message, MessageType
from src.a2a.broker import A2ABroker

async def main():
    broker = A2ABroker()

    async def sub():
        async for msg in broker.subscribe("cluster.wec-east1"):
            print("got:", msg.payload)
            break

    task = asyncio.create_task(sub())
    await broker.publish(Message(
        type=MessageType.EVENT,
        sender_id="agent-a",
        topic="cluster.wec-east1",
        payload={"status": "ready"},
    ))
    await task

asyncio.run(main())
```

Direct messaging between agents:
```python
import asyncio
from src.a2a.protocol import Message, MessageType
from src.a2a.broker import A2ABroker

async def main():
    broker = A2ABroker()
    inbox = await broker.register_direct_inbox("agent-b")

    await broker.send(Message(
        type=MessageType.REQUEST,
        sender_id="agent-a",
        target_id="agent-b",
        payload={"op": "ping"},
    ))

    msg = await asyncio.wait_for(inbox.get(), timeout=1)
    assert msg.payload["op"] == "ping"

asyncio.run(main())
```

### Tests
- Ensures a single message is received for topic subscriber.
- Ensures direct message arrives in registered inbox.

### Scope and impact
- Adds protocol and broker only; no behavior changes elsewhere.
- No external dependencies; safe, isolated merge.

### Follow-ups (separate PRs)
- Hook broker into consensus/routing and MCP handlers.
- Add retries/backpressure policy for critical paths.
- Security: verify/authenticate messages using `auth_token` (see security PR).