### PR TITLE
feat(mcp): add export_kubestellar_context function and register it

### DIFF
--- a/src/shared/functions/__init__.py
+++ b/src/shared/functions/__init__.py
@@ -7,6 +7,7 @@ from .gvrc_discovery import GVRCDiscoveryFunction
 from .helm_deploy import HelmDeployFunction
 from .kubeconfig import KubeconfigFunction
 from .kubestellar_management import KubeStellarManagementFunction
+from .kubestellar_context import ExportKubeStellarContextFunction
 from .multicluster_create import MultiClusterCreateFunction
 from .multicluster_logs import MultiClusterLogsFunction
 from .namespace_utils import NamespaceUtilsFunction
@@ -19,6 +20,7 @@ def initialize_functions():
 
     # Register enhanced KubeStellar management function
     function_registry.register(KubeStellarManagementFunction())
+    function_registry.register(ExportKubeStellarContextFunction())
 
     # Register KubeStellar multi-cluster functions
     function_registry.register(MultiClusterCreateFunction())

--- a/src/shared/functions/kubestellar_context.py
+++ b/src/shared/functions/kubestellar_context.py
@@ -1,0 +1,51 @@
+"""Function to export current KubeStellar context to A2A shared context.
+
+This function serializes the latest results from `kubestellar_management` into
+the compact shared context used for AI-to-AI coordination and MCP prompts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..base_functions import BaseFunction
+from ...a2a.context_manager import get_shared_context
+from ...a2a.context import ClusterSnapshot
+
+
+class ExportKubeStellarContextFunction(BaseFunction):
+    def __init__(self) -> None:
+        super().__init__(
+            name="export_kubestellar_context",
+            description="Serialize and publish a compact multi-cluster context snapshot for A2A and MCP use",
+        )
+
+    async def execute(self, **kwargs: Any) -> Dict[str, Any]:
+        ctx = get_shared_context()
+        # Optionally accept a precomputed map from caller
+        cluster_results = kwargs.get("cluster_results")
+        if isinstance(cluster_results, dict):
+            for cluster_name, data in cluster_results.items():
+                snapshot = ClusterSnapshot(
+                    name=cluster_name,
+                    cluster_type=data.get("cluster_type", "unknown"),
+                    resources_by_type=data.get("resources_by_type", {}),
+                    kubestellar_resources=data.get("kubestellar_resources", []),
+                )
+                ctx.update_cluster(snapshot)
+
+        delta = ctx.get_delta_if_changed()
+        return {"status": "success", "delta": delta}
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "cluster_results": {
+                    "type": "object",
+                    "description": "Optional results to merge into shared context (map of cluster -> result)",
+                }
+            },
+        }
+
+


### PR DESCRIPTION
### Summary
Add an MCP-exposed function to export a compact, delta-friendly KubeStellar multi-cluster context for downstream A2A/MCP consumers.

Fixes: #34 

### What’s included
- `src/shared/functions/kubestellar_context.py`
  - `export_kubestellar_context`: merges optional `cluster_results` into the shared context and returns a delta `{hash, context}` when content changes.
- `src/shared/functions/__init__.py`
  - Registers `export_kubestellar_context` so it appears in CLI/MCP tool listings.

### Why
- Provide a single, MCP-accessible way to surface the current multi-cluster state in a compact format suitable for prompts and agent-to-agent exchange.
- Decouples context production from consumers; promotes consistent state sharing.

### Usage
CLI:
```bash
# Merge results and emit delta if changed
kubestellar execute export_kubestellar_context \
  --params '{
    "cluster_results": {
      "cluster1": {
        "cluster_type": "wec",
        "resources_by_type": {"pod": [{"name": "p1"}]},
        "kubestellar_resources": []
      }
    }
  }'
```

Example response:
```json
{
  "status": "success",
  "delta": {
    "hash": "b2f6...c1",
    "context": {
      "v": 1,
      "ctx": {
        "clusters": {
          "cluster1": {
            "n": "cluster1",
            "t": "wec",
            "r": {"pod": [{"name": "p1"}]},
            "k": [],
            "u": 1723123456789
          }
        }
      }
    }
  }
}
```

MCP (tools):
- Function appears as `export_kubestellar_context` with optional `cluster_results` object.
- Returns a delta only when state changes (callers can cache by `hash`).

### Scope and impact
- Additive; no changes to existing flows.
- Safe to merge; consumers can start using the MCP tool without further wiring.

### Follow-ups (separate PRs)
- Publish deltas over A2A broker for subscribers.
- Add end-to-end tests that feed real `kubestellar_management` outputs into this function.
- Optionally expose a “get-latest-context” (read-only) variant without merging input.