### PR TITLE
🐛 fix: "View on GitHub" button hover visibility in Get Started section

### DIFF
--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -220,3 +220,12 @@
     width: 100%;
   }
 }
+
+.githubButton:hover,
+.githubButton:focus {
+  background: var(--ifm-hover-overlay) !important;
+  color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+  box-shadow: 0 2px 8px rgba(50,108,229,0.08);
+  transition: background 0.2s, color 0.2s, border 0.2s;
+}

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -150,10 +150,10 @@ function GetStarted() {
                   5-Minute Tutorial
                 </Link>
                 <Link
-                  className="button button--outline button--lg margin--sm"
-                  href="https://github.com/kubestellar/a2a">
-                  View on GitHub
-                </Link>
+                  className={clsx("button button--outline button--lg margin--sm", styles.githubButton)}
+                    href="https://github.com/kubestellar/a2a">
+                    View on GitHub
+                 </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What this PR does
Fixes the hover and focus styles of the **"View on GitHub"** button in the Get Started section.  
Previously, the button background blended with the page background (white on white), making it invisible on hover.  
This PR ensures the button remains clearly visible and accessible.

## Related issue
Fixes #49 

## Changes made
- Updated `docs-site/src/pages/index.tsx` to apply a custom CSS class for the button.
- Updated `docs-site/src/pages/index.module.css`:
  - Added theme-aware hover/focus styles using Docusaurus variables (`var(--ifm-hover-overlay)`, `var(--ifm-color-primary)`).
  - Removed hardcoded colors.

## How I tested
- Ran local dev server: `npm install && npm start`.
- Verified button hover/focus behavior on:
  - Desktop (≥ 1024px)
  - Tablet (~768px)
  - Mobile (~375px)
- Verified no console errors.
- Built site successfully (`npm run build`).

## Screenshots

**Before (hover blends with background):**
<img width="1850" height="285" alt="hover" src="https://github.com/user-attachments/assets/3e7b1be2-32c1-4f9f-8b13-effb5d6831c3" />

**After (hover remains visible):**
<img width="1850" height="285" alt="fixed" src="https://github.com/user-attachments/assets/f06b874b-ca3e-4d2e-bb8e-2d2b61a334bd" />

## Notes for reviewers
- All styles are theme-aware; no hardcoded white/black values are used.
- Changes are scoped to the "View on GitHub" button only.
- Open to feedback if you’d like a different hover/focus contrast.

### Checklist
- [x] I have reviewed the project's contribution guidelines.
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
