### PR TITLE
🐛 fix: update footer 'Contributing' link to correct path

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -116,7 +116,7 @@ const config: Config = {
             },
             {
               label: 'Contributing',
-              href: 'https://github.com/kubestellar/a2a/blob/main/CONTRIBUTING.md',
+              href: 'https://github.com/kubestellar/a2a/blob/main/docs-site/docs/CONTRIBUTING.md',
             },
           ],
         },


### PR DESCRIPTION
## 🐛 What this PR does
Fixes the broken "Contributing" link in the website footer.  
The link previously pointed to a non-existent file and now correctly points to `a2a/blob/main/docs-site/docs/CONTRIBUTING.md`.

## 📂 Changes made
- Updated footer link from `a2a/blob/main/CONTRIBUTING.md` → `a2a/blob/main/docs-site/docs/CONTRIBUTING.md`

## 🔍 How I tested
- Ran local dev server (`npm start`)
- Clicked on footer "Contributing" link
- Verified it redirects correctly to GitHub

## 📎 Related Issue
Fixes #53 

## ✅ Checklist
- [x] Footer link updated
- [x] Verified link works correctly in browser
- [x] No broken routes
```