### PR TITLE
📖 docs: add contributing guidelines to website

### DIFF
--- a/docs-site/docs/CONTRIBUTING.md
+++ b/docs-site/docs/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Contributing to A2A
 
 Greetings! 👋 We’re grateful for your interest in contributing to the **A2A project**, part of the [KubeStellar](https://github.com/kubestellar) ecosystem.

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -27,6 +27,11 @@ const sidebars: SidebarsConfig = {
       id: 'troubleshooting',
       label: 'Troubleshooting',
     },
+    {
+      type: 'doc',
+      id: 'CONTRIBUTING',
+      label: 'Contributing',
+    },
   ],
 };
 


### PR DESCRIPTION
## What this PR does
Adds the new Contributing Guidelines page to the A2A documentation website.

## Related issue
Fixes #55 

## Changes made
- Added `docs/CONTRIBUTING.md` to website docs
- Updated `sidebars.ts` to include Contributing page

## How I tested
- Ran local dev server with `npm start`
- Verified "Contributing" appears in sidebar
- Checked links and navigation
- Ensured build passes with `npm run build`

## Notes for reviewers
- Content is directly synced from the repo CONTRIBUTING.md
- Open to suggestions for sidebar placement (currently added after "Troubleshooting")
