### PR TITLE
feat(cli): upgrade default model to gemini-2.0-flash and update models list

### DIFF
--- a/src/llm_providers/config.py
+++ b/src/llm_providers/config.py
@@ -148,7 +148,7 @@ class ConfigManager:
             "default_provider": os.environ.get("DEFAULT_LLM_PROVIDER", "gemini"),
             "providers": {
                 "gemini": {
-                    "model": os.environ.get("GEMINI_MODEL", "gemini-1.5-flash"),
+                    "model": os.environ.get("GEMINI_MODEL", "gemini-2.0-flash"),
                     "temperature": float(os.environ.get("LLM_TEMPERATURE", "0.7")),
                 },
                 "claude": {

--- a/src/llm_providers/gemini.py
+++ b/src/llm_providers/gemini.py
@@ -26,6 +26,7 @@ class GeminiProvider(BaseLLMProvider):
     """Google Gemini API provider."""
 
     MODELS = [
+        "gemini-2.0-flash",
         "gemini-1.5-flash",
         "gemini-1.5-pro",
         "gemini-1.0-pro",


### PR DESCRIPTION
**Changes Made:**

* Updated default model in `config.py` to `gemini-2.0-flash`.
* Updated `MODELS` list in `gemini.py` to include `gemini-2.0-flash` at the top.

**Related Issue:**
Issue #58 

**Reasoning:**

* Aligns project with the latest Gemini release.
* Improves performance, reasoning, and multimodal support.
* Ensures future-proofing as `gemini-1.5` models are deprecated.

**Testing:**

* Verified CLI runs with new default model.
* Verified backward compatibility: users can still override with `gemini-1.5-pro`, `gemini-1.0-pro`, etc.