### PR TITLE
docs(readme): fix license section to match Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## What this PR does
Fixes license inconsistency in `README.md`.  
README previously stated MIT but the repository is licensed under Apache 2.0.

## Related issue
Closes #60 

## Changes made
- Updated `README.md` license section to Apache 2.0
- Verified consistency with root LICENSE file

## How I tested
- Manually reviewed README
- Compared with `LICENSE` file

## Notes for reviewers
This is a documentation-only change. No code is affected.

### Checklist
- [x] License section in `README.md` matches LICENSE file
- [x] Verified no other references to MIT remain