### PR TITLE
🐛 fix: correct broken URL in documentation. Closes #62

### DIFF
--- a/docs-site/docs/CONTRIBUTING.md
+++ b/docs-site/docs/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Most contributions here are UI and docs. Please:
 
 ## 📜 Licensing
 
-This project is [Apache 2.0 licensed](https://github.com/kubestellar/a2a/LICENSE).
+This project is [Apache 2.0 licensed](https://github.com/kubestellar/a2a/blob/main/LICENSE).
 By contributing, you agree to the [Developer Certificate of Origin (DCO)](https://github.com/kubestellar/a2a/DCO).
 
 


### PR DESCRIPTION
### Description

Fixed broken url in `a2a/docs-site/docs/CONTRIBUTING.md`

### Related Issue

This fixes #62

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
