### PR TITLE
fix(cli): update default Gemini model to 2.0 Flash in gemini.py

### DIFF
--- a/src/llm_providers/gemini.py
+++ b/src/llm_providers/gemini.py
@@ -43,7 +43,7 @@ class GeminiProvider(BaseLLMProvider):
 
         # Set default model if not specified
         if config.model == "default":
-            config.model = "gemini-1.5-pro"
+            config.model = "gemini-2.0-flash"
 
         # Configure API key
         genai.configure(api_key=config.api_key)


### PR DESCRIPTION
### Description

This PR updates the default Gemini model in `gemini.py` from `gemini-1.5-flash` to `gemini-2.0-flash`.

### 🔧 Changes

* Set default model = `gemini-2.0-flash` in `gemini.py`.

### ✅ Why?

* Keeps CLI aligned with the latest Gemini release.
* Avoids fallback to deprecated 1.5 model.
* Improves performance, reasoning, and multimodal support.

### 🔗 Related Issue

Closes #66 

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] My code follows the project's coding standards.
