### PR TITLE
🐛 Fix  The Bug : Correct Broken URL in documentation

### DIFF
--- a/docs-site/docs/CONTRIBUTING.md
+++ b/docs-site/docs/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Most contributions here are UI and docs. Please:
 
 ## 📜 Licensing
 
-This project is [Apache 2.0 licensed](https://github.com/kubestellar/a2a/LICENSE).
+This project is [Apache 2.0 licensed](https://github.com/kubestellar/a2a/blob/main/LICENSE).
 By contributing, you agree to the [Developer Certificate of Origin (DCO)](https://github.com/kubestellar/a2a/DCO).
 
 


### PR DESCRIPTION
### Description

Fixed the broken URL in `/docs-site/docs/CONTRIBUTING.md`.

### Related Issue

Fixes #62 

### Changes Made

* [x] Fixed incorrect/broken URL in the CONTRIBUTING.md file.
* [ ] Updated …
* [ ] Refactored …
* [ ] Added tests for …

