### PR TITLE
fix(prow): correct PATH for uv and add isort check

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -12,7 +12,7 @@ presubmits:
             - |
               # Install uv package manager
               curl -LsSf https://astral.sh/uv/install.sh | sh
-              export PATH="/root/.cargo/bin:$PATH"
+              export PATH="/root/.local/bin:$PATH"
               
               # Install dependencies
               uv sync --dev
@@ -30,14 +30,9 @@ presubmits:
     clone_uri: 'https://github.com/kubestellar/a2a'
     spec:
       containers:
-        - image: python:3.12
-          command:
-            - /bin/bash
-            - -c
-            - |
               # Install uv package manager
               curl -LsSf https://astral.sh/uv/install.sh | sh
-              export PATH="/root/.cargo/bin:$PATH"
+              export PATH="/root/.local/bin:$PATH"
               
               # Install dependencies
               uv sync --dev
@@ -62,7 +57,7 @@ presubmits:
             - |
               # Install uv package manager
               curl -LsSf https://astral.sh/uv/install.sh | sh
-              export PATH="/root/.cargo/bin:$PATH"
+              export PATH="/root/.local/bin:$PATH"
               
               # Install dependencies
               uv sync --dev
@@ -74,6 +69,10 @@ presubmits:
               # Check formatting with black
               echo "Checking formatting with black..."
               uv run black src/ tests/ --check --diff
+
+              # Check import sorting with isort
+              echo "Checking import sorting with isort..."
+              uv run isort --check-only src/ tests/
               
               # Type check with mypy (non-blocking)
               echo "Type checking with mypy..."


### PR DESCRIPTION
This pull request updates the `.prow.yaml` configuration to improve the Python environment setup and add an import sorting check to the presubmit workflow. The main changes focus on fixing the installation path for the `uv` package manager and introducing `isort` for import sorting verification.

**Python environment setup improvements:**

* Changed the `PATH` export after installing `uv` to use `/root/.local/bin` instead of `/root/.cargo/bin`, ensuring the correct location for installed binaries. [[1]](diffhunk://#diff-d2e5aec2001e1b47d92deae64c9b4b74507ca4d0e2aa05ac22b8a1ce32f87b10L15-R15) [[2]](diffhunk://#diff-d2e5aec2001e1b47d92deae64c9b4b74507ca4d0e2aa05ac22b8a1ce32f87b10L33-R35) [[3]](diffhunk://#diff-d2e5aec2001e1b47d92deae64c9b4b74507ca4d0e2aa05ac22b8a1ce32f87b10L65-R60)

**Presubmit checks enhancements:**

* Added a step to check import sorting using `isort` for both `src/` and `tests/` directories, helping maintain consistent import order in the codebase.

Fixes #81 