### PR TITLE
add escape functionality to terminate current llm/tool call

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import sys
+import time
 from typing import Any, Awaitable, Dict, List, Optional, TypeVar
 
 from prompt_toolkit import PromptSession
@@ -165,17 +166,20 @@ class AgentChat:
             ]
         )
 
-    async def _execute_function(self, function_name: str, args: Dict[str, Any]) -> str:
+    async def _execute_function(self, function_name: str, args: Dict[str, Any]) -> tuple[str, float]:
         """Execute a KubeStellar function."""
         function = function_registry.get(function_name)
         if not function:
-            return f"Error: Unknown function '{function_name}'"
+            return f"Error: Unknown function '{function_name}'",0.0
 
         try:
-            result = await function.execute(**args)
-            return json.dumps(result, indent=2)
+            start = time.perf_counter() 
+            result_dict = await function.execute(**args)
+            elapsed = time.perf_counter() - start
+            return json.dumps(result_dict, indent=2), elapsed
         except Exception as e:
-            return f"Error executing {function_name}: {str(e)}"
+            return f"Error executing {function_name}: {str(e)}", 0.0
+
 
     def _prepare_tools(self) -> List[Dict[str, Any]]:
         """Prepare available tools for the LLM."""
@@ -284,7 +288,7 @@ class AgentChat:
                         with self.console.status(
                             f"[dim]⚙️  Executing: {tool_call.name}[/dim]", spinner="dots"
                         ):
-                            result = await self._run_with_cancel(
+                            result,elapsed = await self._run_with_cancel(
                                 self._execute_function(tool_call.name, tool_call.arguments)
                             )
                         if result is None:        
@@ -296,7 +300,8 @@ class AgentChat:
 
                         # Display completion
                         self.console.print(
-                            f"[green]✓[/green] [dim]Completed: {tool_call.name}[/dim]"
+                            f"[green]✓[/green] [dim]Completed: {tool_call.name} "
+                            f"({elapsed:.3f}s)[/dim]"
                         )
 
                 # If we have tool results, we need to get AI's response to process the data


### PR DESCRIPTION
### Description

<!-- Clearly describe the purpose of this PR. Include any relevant details or context. -->
earlier we have to wait for the current llm/tool call but now we can terminate the call if we dont want to waste tokens via an escape button
### Related Issue

<!-- Link the issue(s) this PR addresses. -->

Fixes #<issue_number>

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

### Additional Notes

<!-- Add any other context, suggestions, or questions related to this PR. -->
