### PR TITLE
Rename project from KubeStellar Agent to KubeStellar A2A

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KubeStellar Agent
+# KubeStellar A2A
 
 📚 **[View Full Documentation](https://kubestellar.github.io/a2a/)**
 


### PR DESCRIPTION
This pull request updates the project name in the `README.md` to reflect the new branding. The change ensures consistency with current documentation and naming conventions. 

* Updated the project name from "KubeStellar Agent" to "KubeStellar A2A" in the `README.md` header.