### PR TITLE
Change KubeStellar logo to use online image

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <p align="center">
-  <img alt="KubeStellar Logo" width="250px" src="frontend/public/Kubestellar-logo.png" />
+  <img alt="KubeStellar Logo" width="250px" src="https://avatars.githubusercontent.com/u/134407106?s=200&v=4" />
 </p>
 
   


### PR DESCRIPTION
This pull request updates the KubeStellar logo image source in the documentation site to use the project's GitHub avatar instead of a local image file.

Documentation update:

* Changed the logo image in `docs-site/README.md` to reference the GitHub-hosted avatar, improving reliability and consistency.