### PR TITLE
fix: Navbar toggle alignment issue in mobile view

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -117,3 +117,11 @@ pre code {
     --ifm-font-size-base: 15px;
   }
 }
+
+@media (max-width: 996px) {
+  .navbar__toggle {
+    right: 16px !important;
+    left: auto !important;
+    position: absolute !important;
+  }
+}


### PR DESCRIPTION
This PR fixes the navbar alignment issue on mobile devices.
Previously, the toggle icon appeared to the left of the logo and site name, which was inconsistent with common UI design practices.

**Changes Made:**

- Adjusted CSS structure for proper alignment.

Linked Issue:
Closes #98 

Before:
<img width="438" height="635" alt="Screenshot from 2025-10-26 19-50-30" src="https://github.com/user-attachments/assets/a993713d-61b4-418f-b837-64ae67888347" />

After:
<img width="438" height="635" alt="Screenshot from 2025-10-26 19-50-41" src="https://github.com/user-attachments/assets/6e0e447c-eacd-4058-a124-eec279497ef1" />
