### PR TITLE
Add Chat History Persistence in Chatbot Using localStorage

### DIFF
--- a/docs-site/src/components/ProjectBot.tsx
+++ b/docs-site/src/components/ProjectBot.tsx
@@ -54,6 +54,9 @@ const faq: FAQItem[] = [
   }
 ];
 
+// Storage key for localStorage
+const STORAGE_KEY = 'kubestellar-chat-history';
+
 // Gemini API function
 async function fetchGeminiAnswer(apiKey: string, question: string): Promise<string> {
   if (!apiKey) {
@@ -172,6 +175,33 @@ export default function ProjectBot() {
   const inputRef = useRef<HTMLInputElement>(null);
   const [fullscreen, setFullscreen] = useState(false);
 
+  useEffect(() => {
+    try {
+      const savedHistory = localStorage.getItem(STORAGE_KEY);
+      if (savedHistory) {
+        const parsed = JSON.parse(savedHistory);
+        // Convert timestamp strings back to Date objects
+        const historyWithDates = parsed.map((item: any) => ({
+          ...item,
+          timestamp: new Date(item.timestamp)
+        }));
+        setHistory(historyWithDates);
+      }
+    } catch (error) {
+      // Silently handle errors
+    }
+  }, []);
+
+
+  useEffect(() => {
+    if (history.length > 0) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+      } catch (error) {
+      }
+    }
+  }, [history]);
+
   // Auto-scroll function
   const scrollToBottom = () => {
     if (historyRef.current) {
@@ -245,6 +275,12 @@ export default function ProjectBot() {
 
   function handleClear() {
     setHistory([]);
+    // Also clear from localStorage
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      // Silently handle errors
+    }
   }
 
   function formatAnswer(answer: string) {


### PR DESCRIPTION
### Summary
This PR adds **conversation history persistence** to the chatbot.  
Now, chat history will be **saved in localStorage** so that users don’t lose their previous messages after refreshing or reopening the docs site.

### Changes
- Implemented localStorage-based persistence to store user and bot messages.
- Loaded stored chat history on component mount.
- Automatically updated localStorage after each new message.

### Update
Previously, the chatbot’s conversation was lost after a page reload, which affected user experience.  
With this update, the conversation continues seamlessly, improving usability and making interactions more natural.

### Testing
- Verified that messages persist after reloads.
- Confirmed that clearing cache removes stored chats.

### Demo
[Screencast from 2025-10-30 08-47-06.webm](https://github.com/user-attachments/assets/e4b20089-80b7-4365-91ee-e4a6056e21cf)
