### PR TITLE
Add Timestamp Display to User Messages in Chatbot

### DIFF
--- a/docs-site/src/components/ProjectBot.module.css
+++ b/docs-site/src/components/ProjectBot.module.css
@@ -384,3 +384,9 @@
     border-radius: 0 !important;
   }
 }
+
+.messageTime {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+}

--- a/docs-site/src/components/ProjectBot.tsx
+++ b/docs-site/src/components/ProjectBot.tsx
@@ -427,9 +427,12 @@ export default function ProjectBot() {
                 <div key={idx} className={styles.conversation}>
                   <div className={styles.userMessage}>
                     <div className={styles.messageHeader}>
-                      <span className={styles.userIcon}>👤</span>
+                     <span className={styles.userIcon}>👤</span>
                       <span className={styles.userName}>You</span>
-                    </div>
+                       <span className={styles.messageTime}>
+                        {new Date(item.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
+                       </span>
+                      </div>
                     <div className={styles.messageText}>{item.q}</div>
                   </div>
                   {(item.a || isTyping || (isShowingTypingEffect && idx === history.length - 1)) && (


### PR DESCRIPTION
### Summary
This PR enhances the chatbot UI by adding **timestamps** to each user message, improving clarity and user experience — especially in longer conversations.

---

### Changes Made
- **Updated Chat Message Component:**
  - Added a new element to display the message timestamp.
  - Timestamp format: `hh:mm` (24-hour format, local time).

- **Updated Styles (CSS):**

---
<img width="463" height="170" alt="Screenshot from 2025-10-31 15-58-54" src="https://github.com/user-attachments/assets/2a248681-cc62-4fbb-a75c-8b81c02ee128" />
