### PR TITLE
Add Copy Button and Copied State for Chatbot Responses

### DIFF
--- a/docs-site/src/components/ProjectBot.module.css
+++ b/docs-site/src/components/ProjectBot.module.css
@@ -405,3 +405,100 @@
   color: var(--ifm-color-emphasis-500);
   pointer-events: none;
 }
+
+.messageActions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  margin-left: 28px;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.conversation:hover .messageActions {
+  opacity: 1;
+}
+
+.actionButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-height: 32px;
+}
+
+.actionButton:hover {
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+.actionButton.copied {
+  background: var(--ifm-color-success-contrast-background);
+  border-color: var(--ifm-color-success);
+  color: var(--ifm-color-success-dark);
+}
+
+.actionIcon {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.actionButton span {
+  font-weight: 500;
+}
+
+/* Dark mode support */
+[data-theme='dark'] .actionButton {
+  border-color: var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-600);
+}
+
+[data-theme='dark'] .actionButton:hover {
+  background: var(--ifm-color-emphasis-200);
+  border-color: var(--ifm-color-emphasis-500);
+  color: var(--ifm-color-emphasis-800);
+}
+
+[data-theme='dark'] .actionButton.copied {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgb(34, 197, 94);
+  color: rgb(34, 197, 94);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 480px) {
+  .messageActions {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  
+  .actionButton {
+    padding: 4px 8px;
+    font-size: 0.75rem;
+    min-height: 28px;
+  }
+  
+  .actionIcon {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+/* Smooth animations */
+.actionButton.copied .actionIcon {
+  animation: checkmark 0.3s ease-in-out;
+}
+
+@keyframes checkmark {
+  0% { transform: scale(0.8); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}

--- a/docs-site/src/components/ProjectBot.tsx
+++ b/docs-site/src/components/ProjectBot.tsx
@@ -173,11 +173,30 @@ export default function ProjectBot() {
   const [isTyping, setIsTyping] = useState(false);
   const [currentlyTyping, setCurrentlyTyping] = useState<string>("");
   const [isShowingTypingEffect, setIsShowingTypingEffect] = useState(false);
+  const [copiedStates, setCopiedStates] = useState<CopyState>({});
   
   const historyRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const typingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const copyToClipboard = async (text: string, messageIndex: number) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedStates(prev => ({ ...prev, [messageIndex]: true }));
+      
+      // Reset after 2 seconds
+      setTimeout(() => {
+        setCopiedStates(prev => {
+          const newState = { ...prev };
+          delete newState[messageIndex];
+          return newState;
+        });
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
 
   useEffect(() => {
     try {
@@ -452,6 +471,32 @@ export default function ProjectBot() {
                           </div>
                         )}
                       </div>
+                      {item.a && (
+                        <div className={styles.messageActions}>
+                          <button 
+                            className={`${styles.actionButton} ${copiedStates[idx] ? styles.copied : ''}`}
+                            onClick={() => copyToClipboard(item.a, idx)}
+                            title={copiedStates[idx] ? "Copied!" : "Copy message"}
+                          >
+                       {copiedStates[idx] ? (
+                              <>
+                                <svg className={styles.actionIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                                  <polyline points="20,6 9,17 4,12"></polyline>
+                                </svg>
+                                <span>Copied</span>
+                              </>
+                            ) : (
+                              <>
+                                <svg className={styles.actionIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                  <path d="m5,9 0,-2a2,2 0 0,1 2,-2h2"></path>
+                                </svg>
+                                <span>Copy</span>
+                              </>
+                            )}
+                          </button>
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
### Summary
This PR introduces a **copy-to-clipboard feature** for chatbot responses, allowing users to easily copy any AI-generated message with a single click.

---

### 💡 Features Implemented
- **Copy Button:** Each chatbot response now includes a small button to copy text.
- **Visual Feedback:**
  - Displays “Copy” initially.
  - Changes to “Copied ✅” once the text is copied.
- **SVG Icons:** Added subtle SVG icons for copy and check states.
- **Dynamic Classes:** Button dynamically updates style using `copiedStates[idx]`.
- **Keyboard & Accessibility Support:** Added `title` attributes for better accessibility.
- CSS Updates

---
[Screencast from 2025-10-31 16-39-45.webm](https://github.com/user-attachments/assets/14bf7ab5-6b20-4466-9768-a516ab7cf27f)
