### PR TITLE
feat(cli): display default LLM provider in 'providers' command

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -189,9 +189,12 @@ def show_config():
 def list_providers_cmd():
     """List available LLM providers."""
     providers = list_providers()
+    config_manager = get_config_manager()
+    default_provider = config_manager.get_default_provider()
     click.echo("Available LLM providers:")
     for provider in providers:
-        click.echo(f"  - {provider}")
+        marker = " (default)" if provider == default_provider else ""
+        click.echo(f"  - {provider}{marker}")
 
 
 def main():


### PR DESCRIPTION
### Summary
Enhanced the `providers` CLI command to indicate which LLM provider is currently set as the default.

### Changes
- Added `config_manager` usage in `list_providers_cmd()`
- Fetched `default_provider` using `get_default_provider()`
- Displayed `(default)` marker next to the active provider in the list

### Before
<img width="662" height="89" alt="before" src="https://github.com/user-attachments/assets/2d8b2aac-869e-40f0-bb19-6fe59e4ed941" />

### After
<img width="662" height="89" alt="after" src="https://github.com/user-attachments/assets/7658a0a8-f6ff-4595-a626-9252f1dabfd5" />


### Why
This helps users easily identify which LLM provider is currently active as their default configuration.

### Notes
- The default provider is determined by the user's configuration (e.g., when they set an API key or explicitly set a default).