### PR TITLE
fix: Import BindingPolicyManagement and HelmDeployFunction

### DIFF
--- a/src/shared/functions/__init__.py
+++ b/src/shared/functions/__init__.py
@@ -1,6 +1,7 @@
 """Function implementations."""
 
 from src.shared.base_functions import function_registry
+from src.shared.functions.binding_policy_management import BindingPolicyManagement
 from src.shared.functions.deploy_to import DeployToFunction
 from src.shared.functions.describe_resource import DescribeResourceFunction
 from src.shared.functions.edit_resource import EditResourceFunction
@@ -8,6 +9,7 @@ from src.shared.functions.get_cluster_labels import GetClusterLabelsFunction
 from src.shared.functions.gvrc_discovery import GVRCDiscoveryFunction
 from src.shared.functions.helm.list import HelmListFunction
 from src.shared.functions.helm.repo import HelmRepoFunction
+from src.shared.functions.helm_deploy import HelmDeployFunction
 from src.shared.functions.kubeconfig import KubeconfigFunction
 from src.shared.functions.kubestellar_management import KubeStellarManagementFunction
 from src.shared.functions.multicluster_create import MultiClusterCreateFunction


### PR DESCRIPTION
This pull request adds two new function imports to the `src/shared/functions/__init__.py` file, expanding the available shared functions for use in the codebase.

New function imports:

* Added `BindingPolicyManagement` from `src/shared/functions/binding_policy_management` to make binding policy management functionality available.
* Added `HelmDeployFunction` from `src/shared/functions/helm_deploy` to support Helm deployment operations.