### PR TITLE
Enable per-command provider mode overrides in CLI

### DIFF
--- a/src/shared/base_functions.py
+++ b/src/shared/base_functions.py
@@ -64,6 +64,12 @@ class FunctionRegistry:
     def __init__(self):
         self._functions: Dict[str, BaseFunction] = {}
 
+    def reset(self) -> None:
+        """Clear all registered functions and restore defaults."""
+        self._functions = {}
+        # Ensure core plan function is always available after reset
+        self.register(CreatePlanFunction())
+
     def register(self, function: BaseFunction) -> None:
         """Register a new function."""
         self._functions[function.name] = function

--- a/src/shared/providers/__init__.py
+++ b/src/shared/providers/__init__.py
@@ -1,0 +1,12 @@
+"""Provider abstraction for cluster backends."""
+
+from .base import ClusterContext, ClusterProvider, ProviderMode
+from .registry import ensure_default_providers, get_provider_registry
+
+__all__ = [
+    "ClusterContext",
+    "ClusterProvider",
+    "ProviderMode",
+    "ensure_default_providers",
+    "get_provider_registry",
+]

--- a/src/shared/providers/base.py
+++ b/src/shared/providers/base.py
@@ -1,0 +1,40 @@
+"""Provider interfaces shared across CLI and agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, Optional, Protocol
+
+
+class ProviderMode(str, Enum):
+    """Supported backend modes."""
+
+    KUBESTELLAR = "kubestellar"
+    KUBERNETES = "kubernetes"
+
+
+@dataclass
+class ClusterContext:
+    """Minimal context information about a cluster target."""
+
+    name: str
+    context: str
+    labels: Dict[str, str]
+    api_endpoint: Optional[str] = None
+    is_kubestellar: bool = False
+
+
+class ClusterProvider(Protocol):
+    """Abstraction for cluster discovery and capability checks."""
+
+    mode: ProviderMode
+
+    def describe(self) -> str:
+        """Human readable description of the provider."""
+
+    async def discover_clusters(self, kubeconfig: str | None = None) -> Iterable[ClusterContext]:
+        """Return a list of clusters for the active mode."""
+
+    def supports_function(self, function_name: str) -> bool:
+        """Return whether a function should be exposed in this mode."""

--- a/src/shared/providers/detector.py
+++ b/src/shared/providers/detector.py
@@ -1,0 +1,52 @@
+"""Provider mode detection utilities."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+from src.shared.providers.base import ProviderMode
+from src.shared.providers.registry import ensure_default_providers
+
+
+def detect_mode(kubeconfig: str | None = None) -> ProviderMode:
+    """Infer the provider mode based on cluster capabilities."""
+
+    registry = ensure_default_providers()
+
+    if not shutil.which("kubectl"):
+        return registry.default_mode()
+
+    cmd = [
+        "kubectl",
+        "get",
+        "bindings.control.kubestellar.io",
+        "-o",
+        "json",
+    ]
+    if kubeconfig:
+        cmd += ["--kubeconfig", kubeconfig]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        return registry.default_mode()
+
+    if result.returncode == 0:
+        try:
+            data = json.loads(result.stdout or "{}")
+            if data.get("items"):
+                return ProviderMode.KUBESTELLAR
+        except json.JSONDecodeError:
+            pass
+
+    if registry.has_mode(ProviderMode.KUBERNETES):
+        return ProviderMode.KUBERNETES
+    return registry.default_mode()

--- a/src/shared/providers/errors.py
+++ b/src/shared/providers/errors.py
@@ -1,0 +1,6 @@
+"""Shared provider errors."""
+
+
+class ProviderNotFoundError(RuntimeError):
+    """Raised when the desired provider mode is not registered."""
+

--- a/src/shared/providers/kubernetes.py
+++ b/src/shared/providers/kubernetes.py
@@ -1,0 +1,51 @@
+"""Vanilla Kubernetes provider implementation."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from src.shared.providers.base import ClusterContext, ClusterProvider, ProviderMode
+from src.shared.utils import run_shell_command_with_cancellation
+
+
+class KubernetesProvider(ClusterProvider):
+    mode = ProviderMode.KUBERNETES
+
+    def describe(self) -> str:
+        return "Standard Kubernetes cluster"
+
+    async def discover_clusters(self, kubeconfig: str | None = None) -> Iterable[ClusterContext]:
+        cmd = ["kubectl", "config", "get-contexts", "-o", "json"]
+        if kubeconfig:
+            cmd += ["--kubeconfig", kubeconfig]
+        result = await run_shell_command_with_cancellation(cmd)
+        if result["returncode"] != 0:
+            return []
+        data = json.loads(result["stdout"] or "{}")
+        contexts = []
+        for ctx in data.get("contexts", []):
+            name = ctx.get("name")
+            if not name:
+                continue
+            # Filter obvious KubeStellar contexts so we don't double expose them
+            if any(sub in name.lower() for sub in ("wds", "its", "kubestellar")):
+                continue
+            contexts.append(
+                ClusterContext(
+                    name=name,
+                    context=name,
+                    labels={},
+                    is_kubestellar=False,
+                )
+            )
+        return contexts
+
+    def supports_function(self, function_name: str) -> bool:
+        kubestellar_only = {
+            "kubestellar_management",
+            "binding_policy_management",
+            "multicluster_create",
+            "multicluster_logs",
+        }
+        return function_name not in kubestellar_only

--- a/src/shared/providers/kubestellar.py
+++ b/src/shared/providers/kubestellar.py
@@ -1,0 +1,42 @@
+"""KubeStellar-specific provider implementation."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from src.shared.providers.base import ClusterContext, ClusterProvider, ProviderMode
+from src.shared.utils import run_shell_command_with_cancellation
+
+
+class KubeStellarProvider(ClusterProvider):
+    mode = ProviderMode.KUBESTELLAR
+
+    def describe(self) -> str:
+        return "KubeStellar multi-cluster control plane"
+
+    async def discover_clusters(self, kubeconfig: str | None = None) -> Iterable[ClusterContext]:
+        cmd = ["kubectl", "get", "bindings.control.kubestellar.io", "-o", "json"]
+        if kubeconfig:
+            cmd += ["--kubeconfig", kubeconfig]
+        result = await run_shell_command_with_cancellation(cmd)
+        if result["returncode"] != 0:
+            return []
+        data = json.loads(result["stdout"] or "{}")
+        contexts = []
+        for item in data.get("items", []):
+            for dest in item.get("spec", {}).get("destinations", []):
+                cluster_id = dest.get("clusterId")
+                if cluster_id:
+                    contexts.append(
+                        ClusterContext(
+                            name=cluster_id,
+                            context=cluster_id,
+                            labels=item.get("metadata", {}).get("labels", {}),
+                            is_kubestellar=True,
+                        )
+                    )
+        return contexts
+
+    def supports_function(self, function_name: str) -> bool:
+        return True  # All existing functions assume KubeStellar today

--- a/src/shared/providers/registry.py
+++ b/src/shared/providers/registry.py
@@ -1,0 +1,68 @@
+"""Registry for cluster providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
+
+from src.shared.providers.base import ClusterProvider, ProviderMode
+
+
+@dataclass
+class ProviderEntry:
+    provider: ClusterProvider
+    supports_default: bool = False
+
+
+class ProviderRegistry:
+    """Singleton registry for providers."""
+
+    def __init__(self):
+        self._providers: Dict[ProviderMode, ProviderEntry] = {}
+
+    def register(
+        self, provider: ClusterProvider, *, supports_default: bool = False
+    ) -> None:
+        self._providers[provider.mode] = ProviderEntry(
+            provider=provider, supports_default=supports_default
+        )
+
+    def get(self, mode: ProviderMode) -> Optional[ClusterProvider]:
+        entry = self._providers.get(mode)
+        return entry.provider if entry else None
+
+    def default_mode(self) -> ProviderMode:
+        for mode, entry in self._providers.items():
+            if entry.supports_default:
+                return mode
+        raise RuntimeError("No default provider registered")
+
+    def available_modes(self) -> Iterable[ProviderMode]:
+        return self._providers.keys()
+
+    def has_mode(self, mode: ProviderMode) -> bool:
+        return mode in self._providers
+
+
+_REGISTRY: Optional[ProviderRegistry] = None
+
+
+def get_provider_registry() -> ProviderRegistry:
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = ProviderRegistry()
+    return _REGISTRY
+
+
+def ensure_default_providers() -> ProviderRegistry:
+    """Register built-in providers if none are registered yet."""
+
+    registry = get_provider_registry()
+    if not any(True for _ in registry.available_modes()):
+        from src.shared.providers.kubernetes import KubernetesProvider
+        from src.shared.providers.kubestellar import KubeStellarProvider
+
+        registry.register(KubernetesProvider(), supports_default=True)
+        registry.register(KubeStellarProvider())
+
+    return registry

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -54,7 +54,9 @@ async def run_subprocess_with_cancellation(
         raise
 
 
-async def run_shell_command_with_cancellation(cmd: List[str]) -> Dict[str, Any]:
+async def run_shell_command_with_cancellation(
+    cmd: List[str], *, input_data: Optional[bytes] = None
+) -> Dict[str, Any]:
     """
     Run a shell command with proper cancellation support.
     This is a convenience wrapper for run_subprocess_with_cancellation.
@@ -65,4 +67,4 @@ async def run_shell_command_with_cancellation(cmd: List[str]) -> Dict[str, Any]:
     Returns:
         Dictionary with returncode, stdout, and stderr
     """
-    return await run_subprocess_with_cancellation(cmd)
+    return await run_subprocess_with_cancellation(cmd, stdin_data=input_data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,15 @@ def runner():
     return CliRunner()
 
 
+def _load_json_from_output(text: str) -> dict:
+    """Extract the JSON payload from CLI output that may include log lines."""
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("{"):
+            return json.loads("\n".join(lines[idx:]))
+    raise AssertionError(f"No JSON payload found in output: {text!r}")
+
+
 def test_cli_help(runner):
     """Test CLI help command."""
     result = runner.invoke(cli, ["--help"])
@@ -54,7 +63,7 @@ def test_execute_function_with_params(runner):
     )
     assert result.exit_code == 0
     # Should get an error response but in valid JSON format
-    output = json.loads(result.output)
+    output = _load_json_from_output(result.output)
     assert "error" in output or "kubeconfig_path" in output
 
 
@@ -65,7 +74,7 @@ def test_execute_function_with_json_params(runner):
     )
     result = runner.invoke(cli, ["execute", "get_kubeconfig", "--params", params])
     assert result.exit_code == 0
-    output = json.loads(result.output)
+    output = _load_json_from_output(result.output)
     assert isinstance(output, dict)
 
 
@@ -94,3 +103,37 @@ def test_execute_invalid_json_params(runner):
     )
     assert result.exit_code == 0
     assert "Error: Invalid JSON parameters" in result.output
+
+
+def test_execute_with_mode_override(runner):
+    """Mode flag should reinitialize providers and log selection."""
+    result = runner.invoke(
+        cli,
+        [
+            "execute",
+            "--mode",
+            "kubestellar",
+            "get_kubeconfig",
+            "--param",
+            "kubeconfig_path=/nonexistent/path",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "* Using mode: kubestellar" in result.output
+    _load_json_from_output(result.output)
+
+
+def test_describe_with_kubeconfig_override(runner):
+    """Kubeconfig flag should emit mode information to stderr."""
+    result = runner.invoke(
+        cli,
+        [
+            "describe",
+            "--kubeconfig",
+            "/tmp/nonexistent-kubeconfig",
+            "get_kubeconfig",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "* Using mode:" in result.output
+    assert "Function: get_kubeconfig" in result.output


### PR DESCRIPTION
This pull request introduces a robust provider abstraction layer for cluster backends, enabling the CLI to support both Kubernetes and KubeStellar modes with auto-detection and explicit overrides. The CLI commands now reinitialize available functions and providers based on the selected or detected mode, and the codebase is refactored to cleanly separate provider logic. Additionally, the test suite is updated to cover mode selection and output handling.

**Provider abstraction and detection:**

* Introduced a provider abstraction layer with `ProviderMode`, `ClusterProvider`, and `ClusterContext`, supporting both Kubernetes and KubeStellar backends. This enables flexible backend selection and discovery. [[1]](diffhunk://#diff-7cfc5c9a207a759bb1569ffae5ffafb2419e0d8dd2cd0029b8fce97e35571596R1-R12) [[2]](diffhunk://#diff-67cb32b6516d0f1939426261595d46cd2bfa2736da4719739d7677792d5bf936R1-R40) [[3]](diffhunk://#diff-24347488f1cd574922a44ba541491087f9fb9b5ef96eb4e2f190d22c49804917R1-R51) [[4]](diffhunk://#diff-a014a5f1b3254f3eafd6ddfaca57a5d3cb1394e899fbca93cbfb31d72f606c09R1-R42)
* Added provider registry and default provider management, allowing registration and lookup of providers and default mode selection.
* Implemented provider mode auto-detection based on the kubeconfig context and cluster capabilities, with a fallback to defaults.

**CLI enhancements:**

* Refactored CLI commands (`list_functions`, `execute`, `describe`) to accept `--mode` and `--kubeconfig` options, triggering provider and function reinitialization according to the selected backend. Mode selection is now logged for user clarity. [[1]](diffhunk://#diff-f48b6fbbecd2be20706e55ff74f1dc5010772ead8370f228741a41a395d0ba08R14-R63) [[2]](diffhunk://#diff-f48b6fbbecd2be20706e55ff74f1dc5010772ead8370f228741a41a395d0ba08R85-R102) [[3]](diffhunk://#diff-f48b6fbbecd2be20706e55ff74f1dc5010772ead8370f228741a41a395d0ba08R147-R160)

**Function registration improvements:**

* Updated function initialization to register only the functions appropriate for the selected provider mode, ensuring that only supported operations are exposed. Added a reset method to the function registry for clean reinitialization. [[1]](diffhunk://#diff-9639bf005115a2b75a5cbb4b72632ff9fe7faca63c9736c449b7183cabea61c1L3-R7) [[2]](diffhunk://#diff-9639bf005115a2b75a5cbb4b72632ff9fe7faca63c9736c449b7183cabea61c1L23-R69) [[3]](diffhunk://#diff-0b4db77a227a14c3c50288b5f85ecc9bcaac0f2f7f7bbee07afc0526156f8977R67-R72)

**Testing and utilities:**

* Enhanced test suite to verify mode selection, CLI output parsing, and correct function exposure. Added a utility for extracting JSON payloads from CLI outputs that may include log lines. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR17-R25) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL57-R66) [[3]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL68-R77) [[4]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR106-R139)
* Improved shell command utility to support input data and proper cancellation, ensuring reliable provider discovery. [[1]](diffhunk://#diff-474da40347413508f35e0f369892de8aff018d628b2cb0d6c9379217159628a0L57-R59) [[2]](diffhunk://#diff-474da40347413508f35e0f369892de8aff018d628b2cb0d6c9379217159628a0L68-R70)

**Error handling:**

* Added a custom error for unregistered provider modes to improve error reporting and robustness.