### PR TITLE
Restore CLI help text for compatibility

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -13,7 +13,9 @@ from src.shared.base_functions import async_to_sync, function_registry
 from src.shared.functions import initialize_functions
 
 
-@click.group(help="Interact with KubeStellar automation functions and agent mode.")
+@click.group(
+    help="KubeStellar Agent - Interact with automation functions and agent mode."
+)
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """Root command for the KubeStellar A2A CLI."""


### PR DESCRIPTION
This pull request contains a minor update to the CLI help text, clarifying the description of the KubeStellar Agent.

- Updated the help text in the `cli` group decorator to better describe the KubeStellar Agent's purpose.



Fixes #152 