### PR TITLE
🐛 Fix scorecard.yml: remove permissions block

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,11 +8,6 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-
 jobs:
   analysis:
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main


### PR DESCRIPTION
Revert permissions block - reusable workflow handles it with read-all.