### PR TITLE
Remove inactive approvers from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,2 @@
 approvers:
-  - MAVRICK-1
   - clubanderson
-  - btwshivam
-


### PR DESCRIPTION
## Summary
- Remove MAVRICK-1 and btwshivam from OWNERS (inactive)
- Repo is being archived on May 1, 2026